### PR TITLE
Aosta, Experiment, Yamitsuki skin information added

### DIFF
--- a/src/assets/characters/aosta.js
+++ b/src/assets/characters/aosta.js
@@ -1,4 +1,4 @@
-import { TIER_R, TIER_SR, TIER_SSR } from '../constants';
+import { TIER_R, TIER_SR, TIER_SSR, SKILL_BOOK } from '../constants';
 import Aosta from './model/Aosta';
 
 export default {
@@ -75,6 +75,31 @@ export default {
     '4B': {
       name: 'Win The Flesh',
       description: 'Grant selected ally 3 stacks :ENHANCE and 3 stacks :DMGRED.',
+    },
+  }),
+  'aosta skin': new Aosta({
+    tier: SKILL_BOOK,
+    sprite: 'https://i.imgur.com/VgB1P4P.png',
+    title: 'Insidious Mastery',
+    passive: {
+      name: 'Wishful Thinking',
+      description: 'Upon death of full HP target by ally, grant ally full HP',
+    },
+    advisor: {
+      name: 'Behind Closed Doors',
+      description: 'Grant selecetd ally 2 stacks :ENHANCE, grant selected enemy 2 stacks of :VUL',
+    },
+    '1B': {
+      name: 'Double-Cross',
+      description: 'Heal all enemies to full HP, grant :STUN',
+    },
+    '2B': {
+      name: 'Fair And Square',
+      description: 'Grant ally 2 stacks of :ENHANCE, grant selected enemy 2 stacks of :VUL',
+    },
+    '4B': {
+      name: 'Supreme Interference',
+      description: 'Grant selected ally :ENHANCE for all turns, grant selected enemy :VUL for all turns',
     },
   }),
 };

--- a/src/assets/characters/experiment.js
+++ b/src/assets/characters/experiment.js
@@ -74,32 +74,32 @@ export default {
     },
     '4B': {
       name: 'Mind Your Manners',
-      description: 'Attack (:crossed_swords: x 3) all enemies. Grant self :SHOCKL. If have :SHOCKL, cannot cast skill.',
+      description: 'Attack (:crossed_swords: x 3) all enemies. Grant self :SHOCKL. If have :SHOCKL, cannot cast skill',
     },
   }),
-  'experiment skin-unreleased': new Experiment({
+  'experiment skin': new Experiment({
     tier: SKILL_BOOK,
     sprite: 'https://i.imgur.com/nVEmdL3.png',
-    title: '?????',
+    title: 'Overcharge Module',
     passive: {
-      name: '?????',
-      description: '?????',
+      name: 'Upgrade Ready',
+      description: 'Upon Resurrection, grant self full HP and :ENHANCE for all turns',
     },
     advisor: {
-      name: '?????',
-      description: '?????',
+      name: 'Pressurize',
+      description: 'Upon Resurrection of gold character, grant full HP and :ENHANCE for all turns',
     },
     '1B': {
-      name: '?????',
-      description: '?????',
+      name: 'Transformation',
+      description: 'Grant self :ENHANCE for all turns, lose half of current HP. If have :SHOCKL, remove :SHOCKL',
     },
     '2B': {
-      name: '?????',
-      description: '?????',
+      name: 'Short Circuit',
+      description: 'Attack (:crossed_swords: x 3.5) front row enemy. Grant self :EXH for all turns. If have :SHOCKL, cannot cast skill',
     },
     '4B': {
-      name: '?????',
-      description: '?????',
+      name: 'High Voltage Bellow',
+      description: 'Attack (:crossed_swords: x 3) all enemies. Grant self :SHOCKL. If have :SHOCKL, cannot cast skill',
     },
   }),
 };

--- a/src/assets/characters/yamitsuki.js
+++ b/src/assets/characters/yamitsuki.js
@@ -1,4 +1,4 @@
-import { TIER_R, TIER_SR, TIER_SSR } from '../constants';
+import { TIER_R, TIER_SR, TIER_SSR, SKILL_BOOK } from '../constants';
 import Yamitsuki from './model/Yamitsuki';
 
 export default {
@@ -12,7 +12,7 @@ export default {
     },
     advisor: {
       name: 'After Dark',
-      description: 'Armor Penetration (:crossed_swords: x 1.3) selected enemy. (CD: 7)',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy. (CD: 7)',
     },
     '1B': {
       name: 'Just Beat It',
@@ -20,7 +20,7 @@ export default {
     },
     '2B': {
       name: 'Beat The Hush',
-      description: 'Armor Penetration (:crossed_swords: x 1.3) selected enemy',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy',
     },
     '4B': {
       name: 'Beat And Defeat',
@@ -37,7 +37,7 @@ export default {
     },
     advisor: {
       name: 'After Dark',
-      description: 'Armor Penetration (:crossed_swords: x 1.3) selected enemy. (CD: 6)',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy. (CD: 6)',
     },
     '1B': {
       name: 'Just Beat It',
@@ -45,7 +45,7 @@ export default {
     },
     '2B': {
       name: 'Beat The Hush',
-      description: 'Armor Penetration (:crossed_swords: x 1.3) selected enemy, remove :ENHANCE and :VIGIL',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy, remove :ENHANCE and :VIGIL',
     },
     '4B': {
       name: 'Beat And Defeat',
@@ -62,7 +62,7 @@ export default {
     },
     advisor: {
       name: 'After Dark',
-      description: 'Armor Penetration (:crossed_swords: x 1.3) selected enemy. (CD: 5)',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy. (CD: 5)',
     },
     '1B': {
       name: 'Just Beat It',
@@ -70,11 +70,36 @@ export default {
     },
     '2B': {
       name: 'Beat The Hush',
-      description: 'Armor Penetration (:crossed_swords: x 1.3) selected enemy, remove :ENHANCE and :VIGIL',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy, remove :ENHANCE and :VIGIL',
     },
     '4B': {
       name: 'Beat And Defeat',
       description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy, grant 2 stacks :VUL and 2 stacks :EXH for 2 turns',
+    },
+  }),
+  'yamitsuki skin': new Yamitsuki({
+    tier: SKILL_BOOK,
+    sprite: 'https://i.imgur.com/PEDEMmr.png',
+    title: 'Dawnblade Killer',
+    passive: {
+      name: 'In Broad Daylight',
+      description: 'Upon turn, if have both :ENHANCE and :DMGRED, trigger self 1-orb skill',
+    },
+    advisor: {
+      name: 'Suspicious Shadow',
+      description: 'Upon turn, if ally has both :ENHANCE and :DMGRED, trigger 1-orb skill',
+    },
+    '1B': {
+      name: 'Dawn Of Judgement',
+      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy. If target has :DMGRED, copy 1 stack of it for 6 turns',
+    },
+    '2B': {
+      name: 'Conviction Verdict',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy. If target has :ENHANCE, copy 1 stack of it for 6 turns',
+    },
+    '4B': {
+      name: 'Acquittal Declared',
+      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy, grant self :ENHANCE and :DMGRED for 3 turns',
     },
   }),
 };


### PR DESCRIPTION
- Aosta, Experiment, Yamitsuki skin information added
- Yamitsuki's 2b skill damage input was incorrect due to the wrong multiplier (1.35, not 1.3). I updated the multipliers into 1.35.
- The only things not added: Yamitsuki skill book and Aosta skill book sprite. Please add them once data mining is complete. The previous Experiment.js file contained Experiment skin' sprite already, so that one I didn't touch.