### PR TITLE
Aosta skin's 1 block skill fixed.

### DIFF
--- a/src/assets/characters/aosta.js
+++ b/src/assets/characters/aosta.js
@@ -91,7 +91,7 @@ export default {
     },
     '1B': {
       name: 'Double-Cross',
-      description: 'Heal all enemies to full HP, grant :STUN',
+      description: 'Heal selected enemy to full HP, grant :STUN',
     },
     '2B': {
       name: 'Fair And Square',


### PR DESCRIPTION
The in-game skill description for Aosta skin's 1 block skill contained a typo, and I copied it without thinking. The typo is fixed. (Heal all enemies -> Heal *selected enemy*)