### PR TITLE
Angelia SR 4-orb skill changed

### DIFF
--- a/src/assets/characters/angelia.js
+++ b/src/assets/characters/angelia.js
@@ -75,7 +75,7 @@ export default {
     },
     '4B': {
       name: 'Prayer Player',
-      description: 'Heal (:crossed_swords: x 1.8) front row ally, grant :EXH, trigger 2-orb skill',
+      description: 'Heal (:crossed_swords: x 1.8) front row ally, grant :EXH, trigger 4-orb skill',
     },
   }),
   'angelia ssr': new Angelia({


### PR DESCRIPTION
Angelia's SR 4-orb skill trigger 4-orb, not 2-orb unlike Angelia R. Aethern reported this in Puggi Daycare, and after confirming this is incorrect I fixed it.