### PR TITLE
Big update!

### DIFF
--- a/src/assets/characters/dylan.js
+++ b/src/assets/characters/dylan.js
@@ -42,7 +42,7 @@ export default {
     },
     '1B': {
       name: 'Shielded Stance',
-      description: 'Grant self (:crossed_swords: x 1.2) Armor and Taunt',
+      description: 'Grant self (:crossed_swords: x 1.2) Armor and :TAUNT',
     },
     '2B': {
       name: 'Shield Your Eyes',
@@ -67,7 +67,7 @@ export default {
     },
     '1B': {
       name: 'Shielded Stance',
-      description: 'Grant self (:crossed_swords: x 1.2) Armor and Taunt',
+      description: 'Grant self (:crossed_swords: x 1.2) Armor and :TAUNT',
     },
     '2B': {
       name: 'Shield Your Eyes',
@@ -92,7 +92,7 @@ export default {
     },
     '1B': {
       name: 'Shielded Stance',
-      description: 'Grant self (:crossed_swords: x 1.2) Armor and Taunt',
+      description: 'Grant self (:crossed_swords: x 1.2) Armor and :TAUNT',
     },
     '2B': {
       name: 'Shield Your Eyes',
@@ -109,7 +109,7 @@ export default {
     title: 'Refined Blaze',
     passive: {
       name: 'You Shall Not Pass',
-      description: 'Has Taunt for all turns. Upon receive Heal, trigger 1-orb skill',
+      description: 'Has :TAUNT for all turns. Upon receive Heal, trigger 1-orb skill',
     },
     advisor: {
       name: 'Indestructible Arms',

--- a/src/assets/characters/golemwalt.js
+++ b/src/assets/characters/golemwalt.js
@@ -112,7 +112,7 @@ export default {
     },
     advisor: {
       name: 'Friends',
-      description: 'Grant all allies Armor Shift (CD:3)',
+      description: 'Grant all allies :ARMORSHIFT (CD: 3)',
     },
     '1B': {
       name: 'Trembling Roar',

--- a/src/assets/characters/jahan.js
+++ b/src/assets/characters/jahan.js
@@ -8,19 +8,19 @@ export default {
     title: 'Aristocrat Brat',
     passive: {
       name: 'Jump Grope',
-      description: 'Upon incoming damage skill, if have Taunt, retaliate with Attack (:crossed_swords: x 1) against selected enemy',
+      description: 'Upon incoming damage skill, if have :TAUNT, retaliate with Attack (:crossed_swords: x 1) against selected enemy',
     },
     advisor: {
       name: 'Trick Is Treat',
-      description: 'Upon incoming damage skill against ally, if ally have Taunt, 20% chance to trigger target 4-orb skill',
+      description: 'Upon incoming damage skill against ally, if ally have :TAUNT, 20% chance to trigger target 4-orb skill',
     },
     '1B': {
       name: 'Dead Giveaway',
-      description: 'Grant self Taunt for 5 turns. Reset front row enemy CD',
+      description: 'Grant self :TAUNT for 5 turns. Reset front row enemy CD',
     },
     '2B': {
       name: 'Dead Wait',
-      description: 'Grant self Taunt for 2 turns and :DMGRED. If have Taunt, Heal (:crossed_swords: x 1.8) self instead',
+      description: 'Grant self :TAUNT for 2 turns and :DMGRED. If have :TAUNT, Heal (:crossed_swords: x 1.8) self instead',
     },
     '4B': {
       name: "Knock 'Em Dead",
@@ -33,19 +33,19 @@ export default {
     title: 'Charms and Noble',
     passive: {
       name: 'Jump Grope',
-      description: 'Upon incoming damage skill, if have Taunt, retaliate with Attack (:crossed_swords: x 1.5) against selected enemy',
+      description: 'Upon incoming damage skill, if have :TAUNT, retaliate with Attack (:crossed_swords: x 1.5) against selected enemy',
     },
     advisor: {
       name: 'Trick Is Treat',
-      description: 'Upon incoming damage skill against ally, if ally have Taunt, 25% chance to trigger target 4-orb skill',
+      description: 'Upon incoming damage skill against ally, if ally have :TAUNT, 25% chance to trigger target 4-orb skill',
     },
     '1B': {
       name: 'Dead Giveaway',
-      description: 'Grant self Taunt for 5 turns. Reset front row enemy CD',
+      description: 'Grant self :TAUNT for 5 turns. Reset front row enemy CD',
     },
     '2B': {
       name: 'Dead Wait',
-      description: 'Grant self Taunt for 2 turns and 2 stacks :DMGRED. If have Taunt, Heal (:crossed_swords: x 1.8) self instead',
+      description: 'Grant self :TAUNT for 2 turns and 2 stacks :DMGRED. If have :TAUNT, Heal (:crossed_swords: x 1.8) self instead',
     },
     '4B': {
       name: "Knock 'Em Dead",
@@ -58,19 +58,19 @@ export default {
     title: 'Sir Dance a Lot',
     passive: {
       name: 'Jump Grope',
-      description: 'Upon incoming damage skill, if have Taunt, retaliate with Attack (:crossed_swords: x 1.5) against selected enemy, grant :POIS',
+      description: 'Upon incoming damage skill, if have :TAUNT, retaliate with Attack (:crossed_swords: x 1.5) against selected enemy, grant :POIS',
     },
     advisor: {
       name: 'Trick Is Treat',
-      description: 'Upon incoming damage skill against ally, if ally have Taunt, 30% chance to trigger target 4-orb skill',
+      description: 'Upon incoming damage skill against ally, if ally have :TAUNT, 30% chance to trigger target 4-orb skill',
     },
     '1B': {
       name: 'Dead Giveaway',
-      description: 'Grant self Taunt for 5 turns. Reset front row enemy CD',
+      description: 'Grant self :TAUNT for 5 turns. Reset front row enemy CD',
     },
     '2B': {
       name: 'Dead Wait',
-      description: 'Grant self Taunt for 2 turns and :DMGRED for 2 turns. If have Taunt, Heal (:crossed_swords: x 1.8) self instead',
+      description: 'Grant self :TAUNT for 2 turns and :DMGRED for 2 turns. If have :TAUNT, Heal (:crossed_swords: x 1.8) self instead',
     },
     '4B': {
       name: "Knock 'Em Dead",
@@ -83,7 +83,7 @@ export default {
     title: 'Shiny Derpy Pinky',
     passive: {
       name: 'Borrowed Steel',
-      description: 'Upon incoming damage skill, if have Taunt, trigger random ally 1-orb skill',
+      description: 'Upon incoming damage skill, if have :TAUNT, trigger random ally 1-orb skill',
     },
     advisor: {
       name: 'Tactical Taunting',
@@ -91,11 +91,11 @@ export default {
     },
     '1B': {
       name: 'Dead Giveaway',
-      description: 'Grant self Taunt for 5 turns. Reset front row enemy CD',
+      description: 'Grant self :TAUNT for 5 turns. Reset front row enemy CD',
     },
     '2B': {
       name: 'Mocking Jab',
-      description: 'Grant self Taunt for 2 turns and 2 stacks :DMGRED. If have Taunt, True Damage (:crossed_swords: x 1) all enemies, grant :EXH and :TEAR',
+      description: 'Grant self :TAUNT for 2 turns and 2 stacks :DMGRED. If have :TAUNT, True Damage (:crossed_swords: x 1) all enemies, grant :EXH and :TEAR',
     },
     '4B': {
       name: 'Pièce De Résistance ',

--- a/src/assets/characters/karnulla.js
+++ b/src/assets/characters/karnulla.js
@@ -41,7 +41,7 @@ export default {
     },
     '1B': {
       name: 'Doom Bloom',
-      description: 'Grant self Taunt and 2 stacks :VIGIL. Reset front row enemy CD',
+      description: 'Grant self :TAUNT and 2 stacks :VIGIL. Reset front row enemy CD',
     },
     '2B': {
       name: 'Annihilate Bloomer',
@@ -49,7 +49,7 @@ export default {
     },
     '4B': {
       name: 'In Full Bloom',
-      description: 'Grant self Taunt and 3 stacks :VIGIL. Reset all enemies CD',
+      description: 'Grant self :TAUNT and 3 stacks :VIGIL. Reset all enemies CD',
     },
   }),
   'karnulla sr': new Karnulla({
@@ -66,7 +66,7 @@ export default {
     },
     '1B': {
       name: 'Doom Bloom',
-      description: 'Grant self Taunt and 2 stacks :VIGIL. Reset front row enemy CD',
+      description: 'Grant self :TAUNT and 2 stacks :VIGIL. Reset front row enemy CD',
     },
     '2B': {
       name: 'Annihilate Bloomer',
@@ -74,7 +74,7 @@ export default {
     },
     '4B': {
       name: 'In Full Bloom',
-      description: 'Grant self Taunt and 3 stacks :VIGIL. Reset all enemies CD',
+      description: 'Grant self :TAUNT and 3 stacks :VIGIL. Reset all enemies CD',
     },
   }),
   'karnulla ssr': new Karnulla({
@@ -91,7 +91,7 @@ export default {
     },
     '1B': {
       name: 'Doom Bloom',
-      description: 'Grant self Taunt and 2 stacks :VIGIL. Reset front row enemy CD',
+      description: 'Grant self :TAUNT and 2 stacks :VIGIL. Reset front row enemy CD',
     },
     '2B': {
       name: 'Annihilate Bloomer',
@@ -99,7 +99,7 @@ export default {
     },
     '4B': {
       name: 'In Full Bloom',
-      description: 'Grant self Taunt and 3 stacks :VIGIL. Reset all enemies CD',
+      description: 'Grant self :TAUNT and 3 stacks :VIGIL. Reset all enemies CD',
     },
   }),
   'karnulla skin-unreleased': new Karnulla({

--- a/src/assets/characters/leah.js
+++ b/src/assets/characters/leah.js
@@ -41,7 +41,7 @@ export default {
     },
     '1B': {
       name: 'Bad Egg',
-      description: 'Attack (:crossed_swords: x 1) random enemy, grant Taunt',
+      description: 'Attack (:crossed_swords: x 1) random enemy, grant :TAUNT',
     },
     '2B': {
       name: 'The Egg Chick',
@@ -66,7 +66,7 @@ export default {
     },
     '1B': {
       name: 'Bad Egg',
-      description: 'Attack (:crossed_swords: x 1) random enemy, grant Taunt',
+      description: 'Attack (:crossed_swords: x 1) random enemy, grant :TAUNT',
     },
     '2B': {
       name: 'The Egg Chick',

--- a/src/assets/characters/model/NigelSP.js
+++ b/src/assets/characters/model/NigelSP.js
@@ -1,0 +1,12 @@
+import BaseCharacter from './core/BaseCharacter';
+import CharStat from './core/CharStat';
+import { BLACK } from '../../constants';
+
+class NigelSP extends BaseCharacter {
+  constructor(param) {
+    super('Nigel', new CharStat(2940, 8822, WHITE), param);
+    this.block = this.stat.block;
+  }
+}
+
+export default NigelSP;

--- a/src/assets/characters/model/YamitsukiSP.js
+++ b/src/assets/characters/model/YamitsukiSP.js
@@ -4,7 +4,7 @@ import { WHITE } from '../../constants';
 
 class YamitsukiSP extends BaseCharacter {
   constructor(param) {
-    super('Sione', new CharStat(2940, 8822, WHITE), param);
+    super('Yamitsuki', new CharStat(2940, 8822, WHITE), param);
     this.block = this.stat.block;
   }
 }

--- a/src/assets/characters/model/YamitsukiSP.js
+++ b/src/assets/characters/model/YamitsukiSP.js
@@ -1,0 +1,12 @@
+import BaseCharacter from './core/BaseCharacter';
+import CharStat from './core/CharStat';
+import { WHITE } from '../../constants';
+
+class YamitsukiSP extends BaseCharacter {
+  constructor(param) {
+    super('Sione', new CharStat(2940, 8822, WHITE), param);
+    this.block = this.stat.block;
+  }
+}
+
+export default YamitsukiSP;

--- a/src/assets/characters/model/core/Status.js
+++ b/src/assets/characters/model/core/Status.js
@@ -101,6 +101,12 @@ const Status = [
     label: 'Armor Shift',
     description: 'Armor Shift: Upon turn, grant self HP equal to 30% of current Armor for each stack. 3 stacks max.',
   },
+  {
+    code: ':CHARISMA',
+    oldCode: 'CHARISMA',
+    label: 'Charisma',
+    description: 'Charisma: Increase all allies\' skill power by 30% for each stack. 3 stacks max.',
+  },
 ];
 
 export default Status;

--- a/src/assets/characters/nigel.js
+++ b/src/assets/characters/nigel.js
@@ -1,5 +1,6 @@
 import { TIER_R, TIER_SR, TIER_SSR, SP, SKILL_BOOK } from '../constants';
 import Nigel from './model/Nigel';
+import NigelSP from './model/NigelSP';
 
 export default {
   'nigel r': new Nigel({
@@ -77,29 +78,29 @@ export default {
       description: 'Attack (:crossed_swords: x 4) front row enemy. If target less than 50% HP, increase skill power by 50% for this turn',
     },
   }),
-  'nigel sp-unreleased': new Nigel({
+  'nigel sp': new Nigel({
     tier: SP,
     sprite: 'https://i.imgur.com/YFtmC85.png',
-    title: '?????',
+    title: 'Tempest Wanderer',
     passive: {
-      name: '?????',
-      description: '?????',
+      name: 'Rebellious Nature',
+      description: 'Upon death of target, grant self :CHARISMA for 3 turns.',
     },
     advisor: {
-      name: '?????',
-      description: '?????',
+      name: 'Passionate Leader',
+      description: 'Upon death of target by ally, grant :CHARISMA for 3 turns.',
     },
     '1B': {
-      name: '?????',
-      description: '?????',
+      name: 'Crimson Slash',
+      description: 'Attack (:crossed_swords: x 0.6) front row and back row enemy.',
     },
     '2B': {
-      name: '?????',
-      description: '?????',
+      name: 'Twin Katana Strike',
+      description: 'Attack (:crossed_swords: x 1) enemy with highest and lowest HP.',
     },
     '4B': {
-      name: '?????',
-      description: '?????',
+      name: 'Blooming Blood Flower',
+      description: 'Armor Penetration (:crossed_swords: x 1.5) enemy with highest and lowest Armor.',
     },
   }),
   'nigel skin-unreleased': new Nigel({

--- a/src/assets/characters/puggi.js
+++ b/src/assets/characters/puggi.js
@@ -80,7 +80,7 @@ export default {
   'puggi ssr': new Puggi({
     tier: TIER_SSR,
     sprite: 'https://i.imgur.com/7lFt0oG.png',
-    title: 'Puggi SSR: Seasoned Traveller',
+    title: 'Seasoned Traveller',
     passive: {
       name: 'False Bravado',
       description: 'Upon death of ally, grant self full HP and Armor.',

--- a/src/assets/characters/puggi.js
+++ b/src/assets/characters/puggi.js
@@ -12,7 +12,7 @@ export default {
     },
     advisor: {
       name: 'Motormouth',
-      description: 'Grant selected ally Taunt. (CD: 3)',
+      description: 'Grant selected ally :TAUNT. (CD: 3)',
     },
     '1B': {
       name: 'Mockingbird',
@@ -37,7 +37,7 @@ export default {
     },
     advisor: {
       name: 'Motormouth',
-      description: 'Grant selected ally Taunt. (CD: 3)',
+      description: 'Grant selected ally :TAUNT. (CD: 3)',
     },
     '1B': {
       name: 'Mockingbird',
@@ -62,7 +62,7 @@ export default {
     },
     advisor: {
       name: 'Motormouth',
-      description: 'Grant selected ally Taunt. (CD: 2)',
+      description: 'Grant selected ally :TAUNT. (CD: 2)',
     },
     '1B': {
       name: 'Mockingbird',
@@ -87,7 +87,7 @@ export default {
     },
     advisor: {
       name: 'Motormouth',
-      description: 'Grant selected ally Taunt. (CD: 1)',
+      description: 'Grant selected ally :TAUNT. (CD: 1)',
     },
     '1B': {
       name: 'Mockingbird',

--- a/src/assets/characters/theodore.js
+++ b/src/assets/characters/theodore.js
@@ -16,7 +16,7 @@ export default {
     },
     '1B': {
       name: 'Sidetrack King',
-      description: 'Grant selected ally Taunt for 3 turns.',
+      description: 'Grant selected ally :TAUNT for 3 turns.',
     },
     '2B': {
       name: 'King Pinned',
@@ -41,7 +41,7 @@ export default {
     },
     '1B': {
       name: 'Sidetrack King',
-      description: 'Grant selected ally Taunt for 3 turns.',
+      description: 'Grant selected ally :TAUNT for 3 turns.',
     },
     '2B': {
       name: 'King Pinned',
@@ -66,7 +66,7 @@ export default {
     },
     '1B': {
       name: 'Sidetrack King',
-      description: 'Grant selected ally Taunt for 3 turns, trigger 1-orb skill.',
+      description: 'Grant selected ally :TAUNT for 3 turns, trigger 1-orb skill.',
     },
     '2B': {
       name: 'King Pinned',
@@ -83,7 +83,7 @@ export default {
     title: 'Cunning Ruler',
     passive: {
       name: 'Ruler\'s Blessing',
-      description: 'Upon turn, if front row ally has over 20%/50%/80% Armor, grant ally Taunt/:TANKU/ :DMGRED.',
+      description: 'Upon turn, if front row ally has over 20%/50%/80% Armor, grant ally :TAUNT/:TANKU/ :DMGRED.',
     },
     advisor: {
       name: 'Ruler\'s Glory',
@@ -91,7 +91,7 @@ export default {
     },
     '1B': {
       name: 'Ruler\'s Decree',
-      description: 'Grant selected ally Taunt for 3 turns, trigger 1-orb skill.',
+      description: 'Grant selected ally :TAUNT for 3 turns, trigger 1-orb skill.',
     },
     '2B': {
       name: 'Ruler\'s Fortification',

--- a/src/assets/characters/yamitsuki.js
+++ b/src/assets/characters/yamitsuki.js
@@ -1,5 +1,6 @@
-import { TIER_R, TIER_SR, TIER_SSR, SKILL_BOOK } from '../constants';
+import { TIER_R, TIER_SR, TIER_SSR, SP, SKILL_BOOK } from '../constants';
 import Yamitsuki from './model/Yamitsuki';
+import YamitsukiSP from './model/YamitsukiSP';
 
 export default {
   'yamitsuki r': new Yamitsuki({
@@ -8,7 +9,7 @@ export default {
     title: 'Shadow Walker',
     passive: {
       name: 'Insult To Injury',
-      description: 'Upon Tier SR, unlock passive skill',
+      description: 'Upon Tier SR, unlock passive skill.',
     },
     advisor: {
       name: 'After Dark',
@@ -16,15 +17,15 @@ export default {
     },
     '1B': {
       name: 'Just Beat It',
-      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy, remove Taunt and :DMGRED',
+      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy, remove Taunt and :DMGRED.',
     },
     '2B': {
       name: 'Beat The Hush',
-      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy.',
     },
     '4B': {
       name: 'Beat And Defeat',
-      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy',
+      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy.',
     },
   }),
   'yamitsuki sr': new Yamitsuki({
@@ -33,7 +34,7 @@ export default {
     title: 'Nevermore Ninja',
     passive: {
       name: 'Insult To Injury',
-      description: 'Upon cast damage skill, if target has :VUL, increase skill power by 50% for this turn',
+      description: 'Upon cast damage skill, if target has :VUL, increase skill power by 50% for this turn.',
     },
     advisor: {
       name: 'After Dark',
@@ -41,15 +42,15 @@ export default {
     },
     '1B': {
       name: 'Just Beat It',
-      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy, remove Taunt and :DMGRED',
+      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy, remove Taunt and :DMGRED.',
     },
     '2B': {
       name: 'Beat The Hush',
-      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy, remove :ENHANCE and :VIGIL',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy, remove :ENHANCE and :VIGIL.',
     },
     '4B': {
       name: 'Beat And Defeat',
-      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy',
+      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy.',
     },
   }),
   'yamitsuki ssr': new Yamitsuki({
@@ -58,7 +59,7 @@ export default {
     title: 'Twin Of Twilight',
     passive: {
       name: 'Insult To Injury',
-      description: 'Upon cast damage skill, if target has :VUL/:EXH, increase skill power by 50% for this turn',
+      description: 'Upon cast damage skill, if target has :VUL/:EXH, increase skill power by 50% for this turn.',
     },
     advisor: {
       name: 'After Dark',
@@ -66,15 +67,15 @@ export default {
     },
     '1B': {
       name: 'Just Beat It',
-      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy, remove Taunt and :DMGRED',
+      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy, remove Taunt and :DMGRED.',
     },
     '2B': {
       name: 'Beat The Hush',
-      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy, remove :ENHANCE and :VIGIL',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy, remove :ENHANCE and :VIGIL.',
     },
     '4B': {
       name: 'Beat And Defeat',
-      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy, grant 2 stacks :VUL and 2 stacks :EXH for 2 turns',
+      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy, grant 2 stacks :VUL and 2 stacks :EXH for 2 turns.',
     },
   }),
   'yamitsuki skin': new Yamitsuki({
@@ -83,23 +84,48 @@ export default {
     title: 'Dawnblade Killer',
     passive: {
       name: 'In Broad Daylight',
-      description: 'Upon turn, if have both :ENHANCE and :DMGRED, trigger self 1-orb skill',
+      description: 'Upon turn, if have both :ENHANCE and :DMGRED, trigger self 1-orb skill.',
     },
     advisor: {
       name: 'Suspicious Shadow',
-      description: 'Upon turn, if ally has both :ENHANCE and :DMGRED, trigger 1-orb skill',
+      description: 'Upon turn, if ally has both :ENHANCE and :DMGRED, trigger 1-orb skill.',
     },
     '1B': {
       name: 'Dawn Of Judgement',
-      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy. If target has :DMGRED, copy 1 stack of it for 6 turns',
+      description: 'Armor Penetration (:crossed_swords: x 0.6) selected enemy. If target has :DMGRED, copy 1 stack of it for 6 turns.',
     },
     '2B': {
       name: 'Conviction Verdict',
-      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy. If target has :ENHANCE, copy 1 stack of it for 6 turns',
+      description: 'Armor Penetration (:crossed_swords: x 1.35) selected enemy. If target has :ENHANCE, copy 1 stack of it for 6 turns.',
     },
     '4B': {
       name: 'Acquittal Declared',
-      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy, grant self :ENHANCE and :DMGRED for 3 turns',
+      description: 'Armor Penetration (:crossed_swords: x 2.4) selected enemy, grant self :ENHANCE and :DMGRED for 3 turns.',
+    },
+  }),
+  'yamitsuki sp': new Yamitsuki({
+    tier: SP,
+    sprite: 'https://i.imgur.com/ZctlAIN.png',
+    title: 'Nature\'s Beauty',
+    passive: {
+      name: 'Witching Hour',
+      description: 'Upon cast skill by ally, if more than one enemy is present, grant :VIGIL.',
+    },
+    advisor: {
+      name: 'Nether Mist',
+      description: 'Upon cast skill by ally, if more than one enemy is present, grant :VIGIL.',
+    },
+    '1B': {
+      name: 'Confetti Shower',
+      description: 'Heal (:crossed_swords: x 0.27)(:crossed_swords: x 0.27) all player characters and grant :VIGIL 2 times in a row. If any target gets over 50% HP during the skill cast, stop immediately.',
+    },
+    '2B': {
+      name: 'Deadly Gold Hairpins',
+      description: 'Armor Penetration (:crossed_swords: x 0.525)(:crossed_swords: x 0.45)(:crossed_swords: x 0.375) all enemies 3 times in a row. If any target falls below 50% HP during the skill cast, stop immediately.',
+    },
+    '4B': {
+      name: 'Blossoming Scarlet',
+      description: 'Armor Penetration (:crossed_swords: x 0.75)(:crossed_swords: x 0.675)(:crossed_swords: x 0.6) all enemies 3 times in a row. If any target dies during the skill cast, stop immediately.',
     },
   }),
 };

--- a/src/assets/characters/yamitsuki.js
+++ b/src/assets/characters/yamitsuki.js
@@ -105,7 +105,7 @@ export default {
   }),
   'yamitsuki sp': new Yamitsuki({
     tier: SP,
-    sprite: 'https://i.imgur.com/ZctlAIN.png',
+    sprite: 'https://i.imgur.com/zf1KJoJ.png',
     title: 'Nature\'s Beauty',
     passive: {
       name: 'Witching Hour',

--- a/src/assets/constants.js
+++ b/src/assets/constants.js
@@ -19,6 +19,7 @@ export const STUN = 'Stun: Can\'t cast skill. Remove upon incoming damage skill.
 export const WARCRY = 'War Cry: Increase skill power by 30% for each stack. 3 stacks max. Upon cast skill, grant self 1 stack.';
 export const ARMORSHIFT = 'Armor Shift: Upon turn, grant self HP equal to 30% of current Armor for each stack. 3 stacks max.';
 export const TAUNT = 'Taunt: Become primary target.';
+export const CHARISMA = 'Charisma: Increases all allies\' skill power by 30% for each stack. 3 stacks max.'
 
 // tier level
 export const TIER_N = 'N';

--- a/src/commands/characters/commandMap.js
+++ b/src/commands/characters/commandMap.js
@@ -7,7 +7,7 @@ import { standardPrefix } from '../../config';
 const mapCharacterNames = (messageArray) => {
   const copiedMessage = [...messageArray];
 
-  // yanbo/yan-bo
+  //yanbo/yan-bo
   if (copiedMessage[0] === `${standardPrefix}yanbo`) {
     copiedMessage[0] = `${standardPrefix}yan-bo`;
   }
@@ -22,11 +22,17 @@ const mapCharacterNames = (messageArray) => {
     copiedMessage[0] = `${standardPrefix}fredrica`;
   }
 
+  //yami/yamitsuki
   if (copiedMessage[0] === `${standardPrefix}yami`) {
     copiedMessage[0] = `${standardPrefix}yamitsuki`;
   }
+  
+  //golem/golemwalt
+  if (copiedMessage[0] === `${standardPrefix}golem`) {
+    copiedMessage[0] = `${standardPrefix}golemwalt`;
+  }
 
-  // angelia skin/black
+  //angelia skin/black
   if (copiedMessage[0] === `${standardPrefix}angelia` && copiedMessage[1] === 'black') {
     copiedMessage[1] = 'skin';
   }


### PR DESCRIPTION
* Golem skin advisor skill should have had ":ARMORSHIFT" rather than "Armor Shift". This is updated.
* Yamitsuki SP section added, skills all punched in. The corresponding YamitsukiSP.js file was created in the model folder, with the correct class (WHITE). Yamitsuki SP sprite also datamined and added. Karen might want to add the sprite to her own and replace the link? I had mine up for now.
* Same thing with Nigel SP ^
* Taunt > :TAUNT. I hope I replaced every single instance. Might have missed some. Check those out.
* Charisma status added in model/core/Status.js, and in assets/constants.js.
* Golemwalt abbreviation (Golem for Golemwalt) added also.